### PR TITLE
Fix infinite rocket grenades from ZM, add unload sound to Lib & ZM when dropping loaded grenades

### DIFF
--- a/ZScript/Weapons/Liberator.zsc
+++ b/ZScript/Weapons/Liberator.zsc
@@ -110,6 +110,7 @@ class FW_Liberator : FollowerWeapon
 		if (wpn.WeaponStatus[LIBS_FLAGS] & LIBF_GRENADELOADED)
 		{
 			Owner.A_DropItem('HDRocketAmmo', 1);
+			Owner.A_StartSound("weapons/grenopen",CHAN_WEAPON);
 		}
 		
 		nogl = wpn.WeaponStatus[LIBS_FLAGS] & LIBF_NOLAUNCHER? 1 : 0;

--- a/ZScript/Weapons/ZM66.zsc
+++ b/ZScript/Weapons/ZM66.zsc
@@ -115,6 +115,7 @@ class FW_ZM66 : FollowerWeapon
 		if (wpn.WeaponStatus[0] & ZM66F_GRENADELOADED)
 		{
 			Owner.A_DropItem('HDRocketAmmo', 1);
+			Owner.A_StartSound("weapons/grenopen",CHAN_WEAPON);
 		}
 		
 		nogl = wpn.WeaponStatus[ZM66S_FLAGS] & ZM66F_NOLAUNCHER? 1 : 0;
@@ -125,6 +126,8 @@ class FW_ZM66 : FollowerWeapon
 	override void OnBackTransfer(HDWeapon wpn)
 	{
 		wpn.WeaponStatus[ZM66S_MAG] = Mag;
+		
+		wpn.weaponstatus[ZM66S_FLAGS]&=~ZM66F_GRENADELOADED;
 		
 		if(ChamberedRound > 0)wpn.weaponstatus[ZM66S_FLAGS]|=ZM66F_CHAMBER;
 		else wpn.weaponstatus[ZM66S_FLAGS]&=~ZM66F_CHAMBER;


### PR DESCRIPTION
Fixes the infinite grenade exploit that seems to have been missed with the ZM, and also adds a sound for when followers drop a loaded grenade from the ZM and Lib for flavor and to make it more clear to a player when it happens.